### PR TITLE
bugfix: get correct ipfs url

### DIFF
--- a/handlers/content.ts
+++ b/handlers/content.ts
@@ -1,7 +1,7 @@
 import { Context, Handler } from "openapi-backend";
 import Busboy from "busboy";
 import type * as T from "../types/openapi.js";
-import { ipfsPin, ipfsUrl } from "../services/ipfs.js";
+import {ipfsPin, ipfsUrl} from "../services/ipfs.js";
 import * as dsnp from "../services/dsnp.js";
 import { createImageAttachment, createImageLink, createNote } from "@dsnp/activity-content/factories";
 import { publish } from "../services/announce.js";

--- a/services/feed.ts
+++ b/services/feed.ts
@@ -7,7 +7,7 @@ import { hexToString } from "@polkadot/util";
 import axios from "axios";
 import { ParquetReader } from "@dsnp/parquetjs";
 import { MessageResponse } from "@frequency-chain/api-augment/interfaces";
-import { ipfsUrl, localIpfsUrl } from "./ipfs.js";
+import { ipfsUrl } from "./ipfs.js";
 
 type Post = T.Components.Schemas.BroadcastExtended;
 interface CachedPosts {
@@ -51,7 +51,7 @@ const getPostsForBlockRange = async ({ from, to }: BlockRange): Promise<[number,
   // Fetch the parquet files
   for await (const msg of messages) {
     try {
-      const parquetFileUrl = localIpfsUrl(msg.cid);
+      const parquetFileUrl = ipfsUrl(msg.cid);
       const resp = await axios.get(parquetFileUrl, {
         responseType: "arraybuffer",
         timeout: 10_000,

--- a/services/ipfs.ts
+++ b/services/ipfs.ts
@@ -14,6 +14,7 @@ export interface FilePin {
   hash: string;
 }
 
+const CID_PLACEHOLDER = "[CID]"
 // IPFS Kubo API Information
 const ipfsEndpoint = process.env.IPFS_ENDPOINT;
 const ipfsAuthUser = process.env.IPFS_BASIC_AUTH_USER;
@@ -91,10 +92,9 @@ export const ipfsPin = async (mimeType: string, file: Buffer): Promise<FilePin> 
   return { ...ipfs, hash };
 };
 
-export const localIpfsUrl = (cid: string): string => {
-  return ipfsGateway.replace("[CID]", cid);
-};
-
 export const ipfsUrl = (cid: string): string => {
+  if (ipfsGateway.includes(CID_PLACEHOLDER)) {
+    return ipfsGateway.replace(CID_PLACEHOLDER, cid);
+  }
   return `https://ipfs.io/ipfs/${cid}`;
 };


### PR DESCRIPTION
# Description
Generated ipfs urls are not compatible with the ipfs gateway url which causes issue when running the app in local ipfs mode